### PR TITLE
Update timescaledb_information api ref

### DIFF
--- a/api-reference/timescaledb/informational-views/compression_settings.mdx
+++ b/api-reference/timescaledb/informational-views/compression_settings.mdx
@@ -29,8 +29,11 @@ decompressed by mutable compression.
 ## Samples
 
 ```sql
-CREATE TABLE hypertab (a_col integer, b_col integer, c_col integer, d_col integer, e_col integer);
-SELECT table_name FROM create_hypertable('hypertab', by_range('a_col', 864000000));
+CREATE TABLE hypertab (a_col integer, b_col integer, c_col integer, d_col integer, e_col integer) WITH (
+  tsdb.hypertable,
+  tsdb.partition_column = 'a_col',
+  tsdb.chunk_interval = '864000000'
+);
 
 ALTER TABLE hypertab SET (timescaledb.compress, timescaledb.compress_segmentby = 'a_col,b_col',
   timescaledb.compress_orderby = 'c_col desc, d_col asc nulls last');

--- a/api-reference/timescaledb/informational-views/dimensions.mdx
+++ b/api-reference/timescaledb/informational-views/dimensions.mdx
@@ -75,8 +75,10 @@ The `by_range` and `by_hash` dimension builders are an addition to {TIMESCALE_DB
 Get information about dimensions of a {HYPERTABLE} that has two time-based dimensions.
 
 ``` sql
-CREATE TABLE hyper_2dim (a_col date, b_col timestamp, c_col integer);
-SELECT table_name from create_hypertable('hyper_2dim', by_range('a_col'));
+CREATE TABLE hyper_2dim (a_col date, b_col timestamp, c_col integer) WITH (
+  tsdb.hypertable,
+  tsdb.partition_column = 'a_col'
+);
 SELECT add_dimension('hyper_2dim', by_range('b_col', INTERVAL '7 days'));
 
 SELECT * FROM timescaledb_information.dimensions WHERE hypertable_name = 'hyper_2dim';

--- a/api-reference/timescaledb/informational-views/index.mdx
+++ b/api-reference/timescaledb/informational-views/index.mdx
@@ -91,12 +91,12 @@ FROM timescaledb_information.continuous_aggregates;
 View compression settings for all {HYPERTABLE}s:
 
 ```sql
-SELECT hypertable_name,
-       attname AS column_name,
-       orderby_column_index,
-       segmentby_column_index
+SELECT hypertable,
+       segmentby,
+       orderby,
+       compress_interval_length
 FROM timescaledb_information.hypertable_compression_settings
-ORDER BY hypertable_name, orderby_column_index;
+ORDER BY hypertable;
 ```
 
 ## Available views


### PR DESCRIPTION
Fix three SQL query errors in informational views documentation:
- Fix hypertable_compression_settings query to use correct column names (hypertable, segmentby, orderby, compress_interval_length)
- Update dimensions example to use new CREATE TABLE WITH API instead of deprecated create_hypertable function
- Update compression_settings example to use new CREATE TABLE WITH API

All queries now tested and pass validation.